### PR TITLE
fix: Quaternion is imported from nuscenes.eval.common.utils which

### DIFF
--- a/data_utils/trajectory_api.py
+++ b/data_utils/trajectory_api.py
@@ -4,7 +4,7 @@ import torch
 from nuscenes.prediction import PredictHelper
 
 from mmdet3d.core.bbox import LiDARInstance3DBoxes
-from nuscenes.eval.common.utils import Quaternion
+from pyquaternion import Quaternion
 from mmcv.parallel import DataContainer as DC
 from mmdet.datasets.pipelines import to_tensor
 from nuscenes.utils.data_classes import Box


### PR DESCRIPTION
### Problem
fix: Quaternion is imported from nuscenes.eval.common.utils which lacks it

### Fix
Replace:
```
from nuscenes.eval.common.utils import Quaternion
```

with:
```
from pyquaternion import Quaternion
```

### Files changed
- `data_utils/trajectory_api.py`