### PR TITLE
fix: get_ped_crossing_contour crashes on empty clipped exterior

### DIFF
--- a/data_utils/utils.py
+++ b/data_utils/utils.py
@@ -102,13 +102,19 @@ def get_ped_crossing_contour(polygon: Polygon,
     if lines.type != 'LineString':
         # remove points in intersection results
         lines = [l for l in lines.geoms if l.geom_type != 'Point']
+        if not lines:
+            return None
         lines = ops.linemerge(lines)
+        if lines.is_empty:
+            return None
         
         # same instance but not connected.
         if lines.type != 'LineString':
             ls = []
             for l in lines.geoms:
                 ls.append(np.array(l.coords))
+            if not ls:
+                return None
             
             lines = np.concatenate(ls, axis=0)
             lines = LineString(lines)


### PR DESCRIPTION
### Problem
fix: get_ped_crossing_contour crashes on empty clipped exterior

### Fix
Replace:
```
    if lines.type != 'LineString':
        # remove points in intersection results
        lines = [l for l in lines.geoms if l.geom_type != 'Point']
        lines = ops.linemerge(lines)
        
        # same instance but not connected.
        if lines.type != 'LineString':
            ls = []
            for l in lines.geoms:
                ls.append(np.array(l.coords))
            
            lines = np.concatenate(ls, axis=0)
            lines = LineString(lines)
    if not lines.is_empty:
        return lines
    
    return None
```

with:
```
    if lines.type != 'LineString':
        # remove points in intersection results
        lines = [l for l in lines.geoms if l.geom_type != 'Point']
        if not lines:
            return None
        lines = ops.linemerge(lines)
        if lines.is_empty:
            return None
        
        # same instance but not connected.
        if lines.type != 'LineString':
            ls = []
            for l in lines.geoms:
                ls.append(np.array(l.coords))
            if not ls:
                return None
            
            lines = np.concatenate(ls, axis=0)
            lines = LineString(lines)
    if not lines.is_empty:
        return lines
    
    return None
```

### Files changed
- `data_utils/utils.py`